### PR TITLE
Add question editing option

### DIFF
--- a/app/Livewire/QuestionEdit.php
+++ b/app/Livewire/QuestionEdit.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Qbank\Question;
+use App\Models\Qbank\Subject;
+use App\Models\Qbank\Chapter;
+use Livewire\Component;
+
+class QuestionEdit extends Component
+{
+    public Question $questionModel;
+    public $question;
+    public $options = [];
+    public $correct_answer_index;
+    public $subject_id;
+    public $chapter_id;
+
+    public function mount(Question $question)
+    {
+        if (!auth()->user()->isAdmin()) {
+            return redirect('/');
+        }
+
+        $this->questionModel = $question;
+        $this->question = $question->question;
+        $this->options = json_decode($question->options, true) ?? [];
+        $this->correct_answer_index = $question->correct_answer_index;
+        $this->subject_id = $question->subject_id;
+        $this->chapter_id = $question->chapter_id;
+    }
+
+    public function update()
+    {
+        $this->validate([
+            'question' => 'required|string|max:255',
+            'options' => 'required|array|min:2',
+            'correct_answer_index' => 'required|integer|min:0|max:3',
+            'subject_id' => 'required|exists:subjects,id',
+            'chapter_id' => 'required|exists:chapters,id',
+        ]);
+
+        $this->questionModel->update([
+            'question' => $this->question,
+            'options' => json_encode($this->options),
+            'correct_answer_index' => $this->correct_answer_index,
+            'subject_id' => $this->subject_id,
+            'chapter_id' => $this->chapter_id,
+        ]);
+
+        session()->flash('message', 'Question updated successfully!');
+    }
+
+    public function render()
+    {
+        $subjects = Subject::all();
+        $chapters = Chapter::all();
+
+        return view('livewire.question-edit', [
+            'subjects' => $subjects,
+            'chapters' => $chapters,
+        ]);
+    }
+}
+

--- a/resources/views/livewire/question-edit.blade.php
+++ b/resources/views/livewire/question-edit.blade.php
@@ -1,0 +1,85 @@
+<div class="p-6 bg-white dark:bg-gray-900 dark:text-gray-100 rounded-xl shadow-lg border border-gray-200 dark:border-gray-800 transition-all">
+    {{-- Flash Success Message --}}
+    @if(session()->has('message'))
+        <div class="bg-green-500 text-white p-2 rounded mb-4">
+            {{ session('message') }}
+        </div>
+    @endif
+
+    <h2 class="text-3xl font-extrabold tracking-tight text-gray-900 dark:text-gray-100">Edit Question</h2>
+
+    <form wire:submit.prevent="update" class="space-y-6">
+        <!-- Question Input -->
+        <div>
+            <label for="question" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Question</label>
+            <input type="text" wire:model="question" id="question" class="w-full mt-1 p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white transition-all">
+            @error('question')
+            <span class="text-red-500 text-sm">{{ $message }}</span>
+            @enderror
+        </div>
+
+        <!-- Options Input -->
+        <div>
+            <label for="options" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Options</label>
+            <div class="space-y-3">
+                @for($i = 0; $i < 4; $i++)
+                    <input type="text" wire:model="options.{{ $i }}" placeholder="Option {{ $i + 1 }}" class="w-full p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white transition-all">
+                    @error("options.$i")
+                    <span class="text-red-500 text-sm">{{ $message }}</span>
+                    @enderror
+                @endfor
+            </div>
+        </div>
+
+        <!-- Correct Answer Selection -->
+        <div>
+            <label for="correct_answer_index" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Correct Option</label>
+            <select wire:model="correct_answer_index" id="correct_answer_index" class="w-full mt-1 p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white transition-all" required>
+                <option value="">Select Correct Option</option>
+                <option value="0">Option 1</option>
+                <option value="1">Option 2</option>
+                <option value="2">Option 3</option>
+                <option value="3">Option 4</option>
+            </select>
+            @error('correct_answer_index')
+            <span class="text-red-500 text-sm">{{ $message }}</span>
+            @enderror
+        </div>
+
+        <!-- Subject Selection -->
+        <div>
+            <label for="subject_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Select Subject</label>
+            <select wire:model="subject_id" id="subject_id" class="w-full mt-1 p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white transition-all" required>
+                <option value="">Select Subject</option>
+                @foreach($subjects as $subject)
+                    <option value="{{ $subject->id }}">{{ $subject->name }}</option>
+                @endforeach
+            </select>
+            @error('subject_id')
+            <span class="text-red-500 text-sm">{{ $message }}</span>
+            @enderror
+        </div>
+
+        <!-- Chapter Selection -->
+        <div>
+            <label for="chapter_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Select Chapter</label>
+            <select wire:model="chapter_id" id="chapter_id" class="w-full mt-1 p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white transition-all" required>
+                <option value="">Select Chapter</option>
+                @foreach($chapters as $chapter)
+                    <option value="{{ $chapter->id }}">{{ $chapter->name }}</option>
+                @endforeach
+            </select>
+            @error('chapter_id')
+            <span class="text-red-500 text-sm">{{ $message }}</span>
+            @enderror
+        </div>
+
+        <!-- Submit Button -->
+        <div class="flex justify-end">
+            <button type="submit" class="px-6 py-3 bg-indigo-600 text-white rounded-lg shadow hover:bg-indigo-700 transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-indigo-800 dark:hover:bg-indigo-700 dark:focus:ring-indigo-500">
+                Update Question
+            </button>
+        </div>
+
+    </form>
+</div>

--- a/resources/views/livewire/question-list.blade.php
+++ b/resources/views/livewire/question-list.blade.php
@@ -67,7 +67,7 @@
                     <td class="px-4 py-3">{{ $q->subject->name }}</td>
                     <td class="px-4 py-3">{{ $q->chapter->name }}</td>
                     <td class="px-4 py-3 text-center justify-center">
-                        <button class="px-3 py-1 text-sm font-medium rounded bg-blue-500 text-white hover:bg-blue-600 transition">Edit</button>
+                        <a href="{{ route('questions.edit', $q) }}" class="px-3 py-1 text-sm font-medium rounded bg-blue-500 text-white hover:bg-blue-600 transition">Edit</a>
                         <button class="px-3 py-1 text-sm font-medium rounded bg-red-500 text-white hover:bg-red-600 transition">Delete</button>
                     </td>
                 </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Livewire\QuestionCreate;
 use App\Livewire\QuestionList;
 use App\Livewire\QuestionShow;
+use App\Livewire\QuestionEdit;
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
 
@@ -27,8 +28,7 @@ Route::middleware(['auth'])->prefix('admin')->group(function () {
     Route::get('/questions', QuestionList::class)->name('questions');
     Route::get('/questions/create', QuestionCreate::class)->name('questions.create');
     Route::get('/questions/{question}', QuestionShow::class)->name('questions.show');
-    Route::get('questions/{question}/edit', [QuestionController::class, 'edit'])->name('questions.edit');
-    Route::put('questions/{question}', [QuestionController::class, 'update'])->name('questions.update');
+    Route::get('/questions/{question}/edit', QuestionEdit::class)->name('questions.edit');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add Livewire component for editing questions
- add edit form view and wire it up in question list
- route questions edit to new component

## Testing
- `php -l app/Livewire/QuestionEdit.php`
- `php artisan test` *(fails: require vendor/autoload.php; composer install fails with GitHub 403)*

------
https://chatgpt.com/codex/tasks/task_e_68977bc359a08326bd53d0c43b2c0467