### PR TITLE
feat: add question description, tags, and toast notifications

### DIFF
--- a/app/Livewire/QuestionCreate.php
+++ b/app/Livewire/QuestionCreate.php
@@ -5,12 +5,14 @@ namespace App\Livewire;
 use App\Models\Qbank\Question;
 use App\Models\Qbank\Subject;  // Assuming you have a Subject model
 use App\Models\Qbank\Chapter;  // Assuming you have a Chapter model
+use App\Models\Qbank\Tag;
 use Livewire\Component;
 
 class QuestionCreate extends Component
 {
-    public $question, $options = [], $correct_answer_index;
+    public $question, $description, $options = [], $correct_answer_index;
     public $subject_id, $chapter_id;  // New properties for subject and chapter
+    public $selected_tags = [];
 
     // Mount method to ensure only admin users have access
     public function mount()
@@ -26,23 +28,29 @@ class QuestionCreate extends Component
         // Validate all fields, including subject_id and chapter_id
         $this->validate([
             'question' => 'required|string|max:255',
+            'description' => 'nullable|string',
             'options' => 'required|array|min:2',  // At least 2 options
             'correct_answer_index' => 'required|integer|min:0|max:3',  // Valid index for options
             'subject_id' => 'required|exists:subjects,id',  // Validate subject_id exists in the subjects table
             'chapter_id' => 'required|exists:chapters,id',  // Validate chapter_id exists in the chapters table
+            'selected_tags' => 'array',
+            'selected_tags.*' => 'exists:tags,id',
         ]);
 
         // Create a new question record
-        Question::create([
+        $question = Question::create([
             'question' => $this->question,
+            'description' => $this->description,
             'options' => json_encode($this->options),  // Store options as JSON
             'correct_answer_index' => $this->correct_answer_index,
             'subject_id' => $this->subject_id,  // Pass subject_id
             'chapter_id' => $this->chapter_id,  // Pass chapter_id
         ]);
 
+        $question->tags()->sync($this->selected_tags);
+
         // Provide feedback to the user
-        session()->flash('message', 'Question created successfully!');
+        $this->dispatchBrowserEvent('toast', ['message' => 'Question created successfully!', 'type' => 'success']);
 
         // Reset the form after submission
         $this->reset();
@@ -54,10 +62,12 @@ class QuestionCreate extends Component
         // Get subjects and chapters for dropdown options
         $subjects = Subject::all();  // Assuming you have a Subject model
         $chapters = Chapter::all();  // Assuming you have a Chapter model
+        $tags = Tag::all();
 
         return view('livewire.question-create', [
             'subjects' => $subjects,
             'chapters' => $chapters,
+            'tags' => $tags,
         ]);
     }
 }

--- a/app/Livewire/QuestionEdit.php
+++ b/app/Livewire/QuestionEdit.php
@@ -5,16 +5,19 @@ namespace App\Livewire;
 use App\Models\Qbank\Question;
 use App\Models\Qbank\Subject;
 use App\Models\Qbank\Chapter;
+use App\Models\Qbank\Tag;
 use Livewire\Component;
 
 class QuestionEdit extends Component
 {
     public Question $questionModel;
     public $question;
+    public $description;
     public $options = [];
     public $correct_answer_index;
     public $subject_id;
     public $chapter_id;
+    public $selected_tags = [];
 
     public function mount(Question $question)
     {
@@ -24,41 +27,51 @@ class QuestionEdit extends Component
 
         $this->questionModel = $question;
         $this->question = $question->question;
+        $this->description = $question->description;
         $this->options = json_decode($question->options, true) ?? [];
         $this->correct_answer_index = $question->correct_answer_index;
         $this->subject_id = $question->subject_id;
         $this->chapter_id = $question->chapter_id;
+        $this->selected_tags = $question->tags()->pluck('id')->toArray();
     }
 
     public function update()
     {
         $this->validate([
             'question' => 'required|string|max:255',
+            'description' => 'nullable|string',
             'options' => 'required|array|min:2',
             'correct_answer_index' => 'required|integer|min:0|max:3',
             'subject_id' => 'required|exists:subjects,id',
             'chapter_id' => 'required|exists:chapters,id',
+            'selected_tags' => 'array',
+            'selected_tags.*' => 'exists:tags,id',
         ]);
 
         $this->questionModel->update([
             'question' => $this->question,
+            'description' => $this->description,
             'options' => json_encode($this->options),
             'correct_answer_index' => $this->correct_answer_index,
             'subject_id' => $this->subject_id,
             'chapter_id' => $this->chapter_id,
         ]);
 
-        session()->flash('message', 'Question updated successfully!');
+        $this->questionModel->tags()->sync($this->selected_tags);
+
+        $this->dispatchBrowserEvent('toast', ['message' => 'Question updated successfully!', 'type' => 'success']);
     }
 
     public function render()
     {
         $subjects = Subject::all();
         $chapters = Chapter::all();
+        $tags = Tag::all();
 
         return view('livewire.question-edit', [
             'subjects' => $subjects,
             'chapters' => $chapters,
+            'tags' => $tags,
         ]);
     }
 }

--- a/app/Livewire/QuestionList.php
+++ b/app/Livewire/QuestionList.php
@@ -31,9 +31,16 @@ class QuestionList extends Component
         $this->resetPage();
     }
 
+    public function delete($id)
+    {
+        $question = Question::findOrFail($id);
+        $question->delete();
+        $this->dispatchBrowserEvent('toast', ['message' => 'Question deleted successfully!', 'type' => 'danger']);
+    }
+
     public function render()
     {
-        $questions = Question::with(['subject', 'chapter'])
+        $questions = Question::with(['subject', 'chapter', 'tags'])
             ->when($this->search, function ($q) {
                 $q->where(function ($query) {
                     $query->where('question', 'like', '%' . $this->search . '%')

--- a/app/Models/Qbank/Question.php
+++ b/app/Models/Qbank/Question.php
@@ -6,7 +6,14 @@ use Illuminate\Database\Eloquent\Model;
 
 class Question extends Model
 {
-    protected $fillable = ['question', 'options', 'correct_answer_index', 'subject_id', 'chapter_id'];
+    protected $fillable = [
+        'question',
+        'description',
+        'options',
+        'correct_answer_index',
+        'subject_id',
+        'chapter_id',
+    ];
 
     /**
      * Get the subject associated with the question.
@@ -22,5 +29,13 @@ class Question extends Model
     public function chapter()
     {
         return $this->belongsTo(Chapter::class, 'chapter_id');  // Define the relationship
+    }
+
+    /**
+     * Tags attached to the question.
+     */
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class);
     }
 }

--- a/app/Models/Qbank/Tag.php
+++ b/app/Models/Qbank/Tag.php
@@ -7,4 +7,12 @@ use Illuminate\Database\Eloquent\Model;
 class Tag extends Model
 {
     protected $guarded = [];
+
+    /**
+     * Questions associated with the tag.
+     */
+    public function questions()
+    {
+        return $this->belongsToMany(Question::class);
+    }
 }

--- a/database/migrations/2025_08_09_000000_add_description_to_questions_table.php
+++ b/database/migrations/2025_08_09_000000_add_description_to_questions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->text('description')->nullable()->after('question');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->dropColumn('description');
+        });
+    }
+};

--- a/database/migrations/2025_08_09_000001_create_question_tag_table.php
+++ b/database/migrations/2025_08_09_000001_create_question_tag_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('question_tag', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('question_id')->constrained('questions')->onDelete('cascade');
+            $table->foreignId('tag_id')->constrained('tags')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('question_tag');
+    }
+};

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -133,6 +133,20 @@
 
         {{ $slot }}
 
+        <div id="toast-container" class="fixed bottom-4 right-4 space-y-2 z-50"></div>
+        <script>
+            window.addEventListener('toast', event => {
+                const container = document.getElementById('toast-container');
+                const toast = document.createElement('div');
+                const type = event.detail.type || 'success';
+                const bg = type === 'danger' ? 'bg-red-500' : 'bg-green-500';
+                toast.className = `${bg} text-white px-4 py-2 rounded shadow`;
+                toast.textContent = event.detail.message;
+                container.appendChild(toast);
+                setTimeout(() => toast.remove(), 3000);
+            });
+        </script>
+
         @fluxScripts
     </body>
 </html>

--- a/resources/views/livewire/question-create.blade.php
+++ b/resources/views/livewire/question-create.blade.php
@@ -1,10 +1,4 @@
 <div class="p-6 bg-white dark:bg-gray-900 dark:text-gray-100 rounded-xl shadow-lg border border-gray-200 dark:border-gray-800 transition-all">
-    {{-- Flash Success Message --}}
-    @if(session()->has('message'))
-        <div class="bg-green-500 text-white p-2 rounded mb-4">
-            {{ session('message') }}
-        </div>
-    @endif
 
     <h2 class="text-3xl font-extrabold tracking-tight text-gray-900 dark:text-gray-100">Create New Question</h2>
 
@@ -14,6 +8,15 @@
             <label for="question" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Question</label>
             <input type="text" wire:model="question" id="question" class="w-full mt-1 p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white transition-all">
             @error('question')
+            <span class="text-red-500 text-sm">{{ $message }}</span>
+            @enderror
+        </div>
+
+        <!-- Description Input -->
+        <div>
+            <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>
+            <textarea wire:model="description" id="description" class="w-full mt-1 p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white transition-all"></textarea>
+            @error('description')
             <span class="text-red-500 text-sm">{{ $message }}</span>
             @enderror
         </div>
@@ -70,6 +73,19 @@
                 @endforeach
             </select>
             @error('chapter_id')
+            <span class="text-red-500 text-sm">{{ $message }}</span>
+            @enderror
+        </div>
+
+        <!-- Tag Selection -->
+        <div>
+            <label for="tags" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Tags</label>
+            <select wire:model="selected_tags" id="tags" multiple class="w-full mt-1 p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white transition-all">
+                @foreach($tags as $tag)
+                    <option value="{{ $tag->id }}">{{ $tag->name }}</option>
+                @endforeach
+            </select>
+            @error('selected_tags')
             <span class="text-red-500 text-sm">{{ $message }}</span>
             @enderror
         </div>

--- a/resources/views/livewire/question-edit.blade.php
+++ b/resources/views/livewire/question-edit.blade.php
@@ -1,10 +1,4 @@
 <div class="p-6 bg-white dark:bg-gray-900 dark:text-gray-100 rounded-xl shadow-lg border border-gray-200 dark:border-gray-800 transition-all">
-    {{-- Flash Success Message --}}
-    @if(session()->has('message'))
-        <div class="bg-green-500 text-white p-2 rounded mb-4">
-            {{ session('message') }}
-        </div>
-    @endif
 
     <h2 class="text-3xl font-extrabold tracking-tight text-gray-900 dark:text-gray-100">Edit Question</h2>
 
@@ -14,6 +8,15 @@
             <label for="question" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Question</label>
             <input type="text" wire:model="question" id="question" class="w-full mt-1 p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white transition-all">
             @error('question')
+            <span class="text-red-500 text-sm">{{ $message }}</span>
+            @enderror
+        </div>
+
+        <!-- Description Input -->
+        <div>
+            <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>
+            <textarea wire:model="description" id="description" class="w-full mt-1 p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white transition-all"></textarea>
+            @error('description')
             <span class="text-red-500 text-sm">{{ $message }}</span>
             @enderror
         </div>
@@ -70,6 +73,19 @@
                 @endforeach
             </select>
             @error('chapter_id')
+            <span class="text-red-500 text-sm">{{ $message }}</span>
+            @enderror
+        </div>
+
+        <!-- Tag Selection -->
+        <div>
+            <label for="tags" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Tags</label>
+            <select wire:model="selected_tags" id="tags" multiple class="w-full mt-1 p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white transition-all">
+                @foreach($tags as $tag)
+                    <option value="{{ $tag->id }}">{{ $tag->name }}</option>
+                @endforeach
+            </select>
+            @error('selected_tags')
             <span class="text-red-500 text-sm">{{ $message }}</span>
             @enderror
         </div>

--- a/resources/views/livewire/question-list.blade.php
+++ b/resources/views/livewire/question-list.blade.php
@@ -47,6 +47,7 @@
                 <th class="px-4 py-3 text-left">Options</th>
                 <th class="px-4 py-3 text-left">Subject</th>
                 <th class="px-4 py-3 text-left">Chapter</th>
+                <th class="px-4 py-3 text-left">Tags</th>
                 <th class="px-4 py-3 text-center">Actions</th>
             </tr>
             </thead>
@@ -66,9 +67,14 @@
                     </td>
                     <td class="px-4 py-3">{{ $q->subject->name }}</td>
                     <td class="px-4 py-3">{{ $q->chapter->name }}</td>
+                    <td class="px-4 py-3">
+                        @foreach($q->tags as $tag)
+                            <span class="inline-block bg-gray-200 text-gray-800 rounded px-2 py-0.5 text-xs mr-1">{{ $tag->name }}</span>
+                        @endforeach
+                    </td>
                     <td class="px-4 py-3 text-center justify-center">
                         <a href="{{ route('questions.edit', $q) }}" class="px-3 py-1 text-sm font-medium rounded bg-blue-500 text-white hover:bg-blue-600 transition">Edit</a>
-                        <button class="px-3 py-1 text-sm font-medium rounded bg-red-500 text-white hover:bg-red-600 transition">Delete</button>
+                        <button wire:click="delete({{ $q->id }})" class="px-3 py-1 text-sm font-medium rounded bg-red-500 text-white hover:bg-red-600 transition">Delete</button>
                     </td>
                 </tr>
             @empty


### PR DESCRIPTION
## Summary
- allow questions to include descriptions and tag assignments
- show tags in question list and support deletion with toast feedback
- add toast notification system for create/update/delete actions

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689783eeb61c8326b40caa5a53fdd14f