### PR TITLE
Add sidebar navigation for subject, chapter, and tag management

### DIFF
--- a/resources/views/chapters/add.blade.php
+++ b/resources/views/chapters/add.blade.php
@@ -1,0 +1,5 @@
+<x-layouts.app :title="__('Add Chapter')">
+    <div class="p-4">
+        {{ __('Add Chapter page') }}
+    </div>
+</x-layouts.app>

--- a/resources/views/chapters/delete.blade.php
+++ b/resources/views/chapters/delete.blade.php
@@ -1,0 +1,5 @@
+<x-layouts.app :title="__('Delete Chapter')">
+    <div class="p-4">
+        {{ __('Delete Chapter page') }}
+    </div>
+</x-layouts.app>

--- a/resources/views/chapters/edit.blade.php
+++ b/resources/views/chapters/edit.blade.php
@@ -1,0 +1,5 @@
+<x-layouts.app :title="__('Edit Chapter')">
+    <div class="p-4">
+        {{ __('Edit Chapter page') }}
+    </div>
+</x-layouts.app>

--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -104,6 +104,30 @@
                 </flux:navlist.group>
             </flux:navlist>
 
+            <flux:navlist variant="outline">
+                <flux:navlist.group expandable :heading="__('Question')">
+                    <flux:navlist.item icon="home" :href="route('questions')" :current="request()->routeIs('questions')" wire:navigate>{{ __('Questions') }}</flux:navlist.item>
+
+                    <flux:navlist.group expandable :heading="__('Subject')">
+                        <flux:navlist.item :href="route('subjects.add')" :current="request()->routeIs('subjects.add')" wire:navigate>{{ __('Add Subject') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('subjects.edit')" :current="request()->routeIs('subjects.edit')" wire:navigate>{{ __('Edit Subject') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('subjects.delete')" :current="request()->routeIs('subjects.delete')" wire:navigate>{{ __('Delete Subject') }}</flux:navlist.item>
+                    </flux:navlist.group>
+
+                    <flux:navlist.group expandable :heading="__('Chapter')">
+                        <flux:navlist.item :href="route('chapters.add')" :current="request()->routeIs('chapters.add')" wire:navigate>{{ __('Add Chapter') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('chapters.edit')" :current="request()->routeIs('chapters.edit')" wire:navigate>{{ __('Edit Chapter') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('chapters.delete')" :current="request()->routeIs('chapters.delete')" wire:navigate>{{ __('Delete Chapter') }}</flux:navlist.item>
+                    </flux:navlist.group>
+
+                    <flux:navlist.group expandable :heading="__('Tag')">
+                        <flux:navlist.item :href="route('tags.add')" :current="request()->routeIs('tags.add')" wire:navigate>{{ __('Add Tag') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('tags.edit')" :current="request()->routeIs('tags.edit')" wire:navigate>{{ __('Edit Tag') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('tags.delete')" :current="request()->routeIs('tags.delete')" wire:navigate>{{ __('Delete Tag') }}</flux:navlist.item>
+                    </flux:navlist.group>
+                </flux:navlist.group>
+            </flux:navlist>
+
             <flux:spacer />
 
             <flux:navlist variant="outline">

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -18,8 +18,26 @@
             </flux:navlist>
 
             <flux:navlist variant="outline">
-                <flux:navlist.group :heading="__('Platform')" class="grid">
+                <flux:navlist.group expandable :heading="__('Question')" class="grid">
                     <flux:navlist.item icon="home" :href="route('questions')" :current="request()->routeIs('questions')" wire:navigate>{{ __('Questions') }}</flux:navlist.item>
+
+                    <flux:navlist.group expandable :heading="__('Subject')">
+                        <flux:navlist.item :href="route('subjects.add')" :current="request()->routeIs('subjects.add')" wire:navigate>{{ __('Add Subject') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('subjects.edit')" :current="request()->routeIs('subjects.edit')" wire:navigate>{{ __('Edit Subject') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('subjects.delete')" :current="request()->routeIs('subjects.delete')" wire:navigate>{{ __('Delete Subject') }}</flux:navlist.item>
+                    </flux:navlist.group>
+
+                    <flux:navlist.group expandable :heading="__('Chapter')">
+                        <flux:navlist.item :href="route('chapters.add')" :current="request()->routeIs('chapters.add')" wire:navigate>{{ __('Add Chapter') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('chapters.edit')" :current="request()->routeIs('chapters.edit')" wire:navigate>{{ __('Edit Chapter') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('chapters.delete')" :current="request()->routeIs('chapters.delete')" wire:navigate>{{ __('Delete Chapter') }}</flux:navlist.item>
+                    </flux:navlist.group>
+
+                    <flux:navlist.group expandable :heading="__('Tag')">
+                        <flux:navlist.item :href="route('tags.add')" :current="request()->routeIs('tags.add')" wire:navigate>{{ __('Add Tag') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('tags.edit')" :current="request()->routeIs('tags.edit')" wire:navigate>{{ __('Edit Tag') }}</flux:navlist.item>
+                        <flux:navlist.item :href="route('tags.delete')" :current="request()->routeIs('tags.delete')" wire:navigate>{{ __('Delete Tag') }}</flux:navlist.item>
+                    </flux:navlist.group>
                 </flux:navlist.group>
             </flux:navlist>
 

--- a/resources/views/subjects/add.blade.php
+++ b/resources/views/subjects/add.blade.php
@@ -1,0 +1,5 @@
+<x-layouts.app :title="__('Add Subject')">
+    <div class="p-4">
+        {{ __('Add Subject page') }}
+    </div>
+</x-layouts.app>

--- a/resources/views/subjects/delete.blade.php
+++ b/resources/views/subjects/delete.blade.php
@@ -1,0 +1,5 @@
+<x-layouts.app :title="__('Delete Subject')">
+    <div class="p-4">
+        {{ __('Delete Subject page') }}
+    </div>
+</x-layouts.app>

--- a/resources/views/subjects/edit.blade.php
+++ b/resources/views/subjects/edit.blade.php
@@ -1,0 +1,5 @@
+<x-layouts.app :title="__('Edit Subject')">
+    <div class="p-4">
+        {{ __('Edit Subject page') }}
+    </div>
+</x-layouts.app>

--- a/resources/views/tags/add.blade.php
+++ b/resources/views/tags/add.blade.php
@@ -1,0 +1,5 @@
+<x-layouts.app :title="__('Add Tag')">
+    <div class="p-4">
+        {{ __('Add Tag page') }}
+    </div>
+</x-layouts.app>

--- a/resources/views/tags/delete.blade.php
+++ b/resources/views/tags/delete.blade.php
@@ -1,0 +1,5 @@
+<x-layouts.app :title="__('Delete Tag')">
+    <div class="p-4">
+        {{ __('Delete Tag page') }}
+    </div>
+</x-layouts.app>

--- a/resources/views/tags/edit.blade.php
+++ b/resources/views/tags/edit.blade.php
@@ -1,0 +1,5 @@
+<x-layouts.app :title="__('Edit Tag')">
+    <div class="p-4">
+        {{ __('Edit Tag page') }}
+    </div>
+</x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,18 @@ Route::middleware(['auth'])->prefix('admin')->group(function () {
     Route::get('/questions/create', QuestionCreate::class)->name('questions.create');
     Route::get('/questions/{question}', QuestionShow::class)->name('questions.show');
     Route::get('/questions/{question}/edit', QuestionEdit::class)->name('questions.edit');
+
+    Route::view('/subjects/add', 'subjects.add')->name('subjects.add');
+    Route::view('/subjects/edit', 'subjects.edit')->name('subjects.edit');
+    Route::view('/subjects/delete', 'subjects.delete')->name('subjects.delete');
+
+    Route::view('/chapters/add', 'chapters.add')->name('chapters.add');
+    Route::view('/chapters/edit', 'chapters.edit')->name('chapters.edit');
+    Route::view('/chapters/delete', 'chapters.delete')->name('chapters.delete');
+
+    Route::view('/tags/add', 'tags.add')->name('tags.add');
+    Route::view('/tags/edit', 'tags.edit')->name('tags.edit');
+    Route::view('/tags/delete', 'tags.delete')->name('tags.delete');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- Add hierarchical question management menu with Subject, Chapter, and Tag submenus in sidebar and mobile navigation
- Stub routes and views for Subject, Chapter, and Tag add/edit/delete pages

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: GitHub 403 requiring credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6897891275548326b259670f9e777bfb