### PR TITLE
feat: add admin configurable message retention

### DIFF
--- a/app/Console/Commands/PruneOldMessages.php
+++ b/app/Console/Commands/PruneOldMessages.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Message;
+use App\Models\Setting;
+use Illuminate\Console\Command;
+
+class PruneOldMessages extends Command
+{
+    protected $signature = 'messages:prune';
+
+    protected $description = 'Delete messages older than configured retention time';
+
+    public function handle(): int
+    {
+        $hours = (int) Setting::get('message_retention_hours', 24);
+        $cutoff = now()->subHours($hours);
+        $deleted = Message::where('created_at', '<', $cutoff)->delete();
+        $this->info("Deleted {$deleted} messages older than {$hours} hours.");
+        return self::SUCCESS;
+    }
+}

--- a/app/Livewire/Admin/MessageRetentionSettings.php
+++ b/app/Livewire/Admin/MessageRetentionSettings.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Models\Setting;
+use Livewire\Component;
+
+class MessageRetentionSettings extends Component
+{
+    public $retentionHours;
+
+    protected $rules = [
+        'retentionHours' => 'required|integer|min:1',
+    ];
+
+    public function mount()
+    {
+        $this->retentionHours = Setting::get('message_retention_hours', 24);
+    }
+
+    public function save()
+    {
+        $this->validate();
+        Setting::set('message_retention_hours', $this->retentionHours);
+        session()->flash('message', 'Retention time updated.');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.message-retention-settings');
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Message extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'content',
+    ];
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+
+    public static function get(string $key, $default = null)
+    {
+        return static::query()->where('key', $key)->value('value') ?? $default;
+    }
+
+    public static function set(string $key, $value): self
+    {
+        return static::updateOrCreate(['key' => $key], ['value' => $value]);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\PruneOldMessages;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -15,4 +16,8 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //
-    })->create();
+    })
+    ->withCommands([
+        PruneOldMessages::class,
+    ])
+    ->create();

--- a/database/migrations/2025_08_10_000000_create_messages_table.php
+++ b/database/migrations/2025_08_10_000000_create_messages_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/database/migrations/2025_08_10_000001_create_settings_table.php
+++ b/database/migrations/2025_08_10_000001_create_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->string('value');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -32,6 +32,12 @@
                 </flux:navlist.group>
             </flux:navlist>
 
+            <flux:navlist variant="outline">
+                <flux:navlist.group :heading="__('Settings')" class="grid">
+                    <flux:navlist.item :href="route('admin.message-settings')" :current="request()->routeIs('admin.message-settings')" wire:navigate>{{ __('Message Settings') }}</flux:navlist.item>
+                </flux:navlist.group>
+            </flux:navlist>
+
             <flux:spacer />
 
             <flux:navlist variant="outline">

--- a/resources/views/livewire/admin/message-retention-settings.blade.php
+++ b/resources/views/livewire/admin/message-retention-settings.blade.php
@@ -1,0 +1,21 @@
+<div class="p-4">
+    <h2 class="text-2xl font-bold mb-4">Message Retention Settings</h2>
+
+    @if (session()->has('message'))
+        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
+            <span class="block sm:inline">{{ session('message') }}</span>
+        </div>
+    @endif
+
+    <form wire:submit.prevent="save" class="space-y-4 max-w-sm">
+        <div>
+            <label for="retentionHours" class="block font-medium">Delete messages after (hours)</label>
+            <input id="retentionHours" type="number" min="1" wire:model="retentionHours" class="mt-1 w-full border rounded p-2">
+            @error('retentionHours') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
+        </div>
+
+        <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+            Save
+        </button>
+    </form>
+</div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,10 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('messages:prune')->hourly();

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Livewire\QuestionEdit;
 use App\Livewire\QuestionForm;
 use App\Livewire\QuestionList;
 use App\Livewire\QuestionShow;
+use App\Livewire\Admin\MessageRetentionSettings;
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
 
@@ -45,6 +46,7 @@ Route::middleware(['auth'])->prefix('admin')->group(function () {
     Route::get('/subjects', SubjectManager::class)->name('subjects.index');
     Route::get('/chapters', ChapterManager::class)->name('chapters.index');
     Route::get('/tags', TagManager::class)->name('tags.index');
+    Route::get('/message-settings', MessageRetentionSettings::class)->name('admin.message-settings');
 });
 
 Route::get('/mock-test', MockTestSetup::class)->name('mock.test')->middleware('auth');


### PR DESCRIPTION
## Summary
- add settings and messages tables
- allow admins to set message retention hours
- schedule command to prune old messages

## Testing
- `php artisan test` *(fails: Class "Illuminate\Foundation\Application" not found)*
- `composer install` *(fails: GitHub API rate limit, requires token)*

------
https://chatgpt.com/codex/tasks/task_e_68a72dd36af08326a8f04adc83b3ed99